### PR TITLE
Register services using vnet_pubinterface

### DIFF
--- a/manifests/cc.pp
+++ b/manifests/cc.pp
@@ -34,6 +34,9 @@ class eucalyptus::cc (
     File <<|title == "${cloud_name}_${cluster_name}_vtunpass"|>>
   }
 
+  $registerif = regsubst($eucalyptus::conf::vnet_pubinterface, '\.', '_')
+  $host = getvar("ipaddress_${registerif}")
+
   class eucalyptus::cc_reg inherits eucalyptus::cc {
 
     Class[eucalyptus::cc_reg] -> Class[eucalyptus::cc_config]
@@ -45,10 +48,10 @@ class eucalyptus::cc (
       --no-sync \
       --register-cluster \
       --partition ${cluster_name} \
-      --host ${::ipaddress} \
+      --host ${host} \
       --component cc_${::hostname}",
       unless   => "/usr/sbin/euca_conf --list-clusters | \
-      /bin/grep -q '\b${::ipaddress}\b'",
+      /bin/grep -q '\b${host}\b'",
       tag      => $cloud_name,
     }
 

--- a/manifests/clc2.pp
+++ b/manifests/clc2.pp
@@ -26,6 +26,10 @@ class eucalyptus::clc2 ($cloud_name = "cloud1") {
     Exec <<|tag == "${cloud_name}_euca.p12"|>> ->
     File <<|tag == "${cloud_name}_euca.p12"|>>
   }
+
+  $registerif = regsubst($eucalyptus::conf::vnet_pubinterface, '\.', '_')
+  $host = getvar("ipaddress_${registerif}")
+
   class eucalyptus::clc2_reg inherits eucalyptus::clc2 {
     @@exec { "reg_clc_${::hostname}":
       command => "/usr/sbin/euca_conf \
@@ -34,10 +38,10 @@ class eucalyptus::clc2 ($cloud_name = "cloud1") {
       --no-sync \
       --register-cloud \
       --partition eucalyptus \
-      --host ${::ipaddress} \
+      --host ${host} \
       --component clc_${::hostname}",
       unless => "/usr/sbin/euca_conf --list-clouds | \
-      /bin/grep '\b${::ipaddress}\b'",
+      /bin/grep '\b${host}\b'",
       tag => $cloud_name,
     }
   }

--- a/manifests/nc.pp
+++ b/manifests/nc.pp
@@ -29,6 +29,9 @@ class eucalyptus::nc (
     File <<|title == "${cloud_name}_cloud_cert"|>>
   }
 
+  $registerif = regsubst($eucalyptus::conf::vnet_pubinterface, '\.', '_')
+  $host = getvar("ipaddress_${registerif}")
+
   class eucalyptus::nc_reg inherits eucalyptus::nc {
     #Eucalyptus_config <||> { notify => Service["eucalyptus-nc"] }
     # Causes too many service refreshes
@@ -38,8 +41,8 @@ class eucalyptus::nc (
       --no-rsync \
       --no-sync \
       --no-scp \
-      --register-nodes ${::ipaddress}",
-      unless   => "/bin/grep -i '\b${::ipaddress}\b' /etc/eucalyptus/eucalyptus.conf",
+      --register-nodes ${host}",
+      unless   => "/bin/grep -i '\b${host}\b' /etc/eucalyptus/eucalyptus.conf",
       tag      => "${cloud_name}_${cluster_name}_reg_nc",
     }
   }

--- a/manifests/sc.pp
+++ b/manifests/sc.pp
@@ -31,6 +31,9 @@ class eucalyptus::sc (
     File <<|title == "${cloud_name}_${cluster_name}_cluster_pk"|>>
   }
 
+  $registerif = regsubst($eucalyptus::conf::vnet_pubinterface, '\.', '_')
+  $host = getvar("ipaddress_${registerif}")
+
   class eucalyptus::sc_reg inherits eucalyptus::sc {
 
     Class[eucalyptus::sc_reg] -> Class[eucalyptus::sc_config]
@@ -42,10 +45,10 @@ class eucalyptus::sc (
       --no-sync \
       --register-sc \
       --partition ${cluster_name} \
-      --host ${::ipaddress} \
+      --host ${host} \
       --component sc_${::hostname}",
       unless   => "/usr/sbin/euca_conf --list-scs | \
-      /bin/grep '\b${::ipaddress}\b'",
+      /bin/grep '\b${host}\b'",
       tag      => $cloud_name,
     }
   }

--- a/manifests/walrus.pp
+++ b/manifests/walrus.pp
@@ -31,6 +31,9 @@ class eucalyptus::walrus (
     File <<|tag == "${cloud_name}_euca.p12"|>>
   }
 
+  $registerif = regsubst($eucalyptus::conf::vnet_pubinterface, '\.', '_')
+  $host = getvar("ipaddress_${registerif}")
+
   class eucalyptus::walrus_reg inherits eucalyptus::walrus {
     @@exec { "reg_walrus_${::hostname}":
       command  => "/usr/sbin/euca_conf \
@@ -39,10 +42,10 @@ class eucalyptus::walrus (
       --no-sync \
       --register-walrus \
       --partition walrus \
-      --host ${::ipaddress} \
+      --host ${host} \
       --component walrus_${::hostname}",
       unless   => "/usr/sbin/euca_conf --list-walruses | \
-      /bin/grep '\b${::ipaddress}\b'",
+      /bin/grep '\b${host}\b'",
       tag      => $cloud_name,
     }
   }


### PR DESCRIPTION
On unix-like platforms, facter(8) reports as ipaddress the first
non-127.0.0.1 address it finds from the output of ifconfig(8). On
many setups this will register the components using the private
interface (or some other incorrect IP address).
