### PR TITLE
Fix ordering in cc.pp

### DIFF
--- a/manifests/cc.pp
+++ b/manifests/cc.pp
@@ -39,7 +39,7 @@ class eucalyptus::cc (
 
   class eucalyptus::cc_reg inherits eucalyptus::cc {
 
-    Class[eucalyptus::cc_reg] -> Class[eucalyptus::cc_config]
+    Class[eucalyptus::cc_config] -> Class[eucalyptus::cc_reg]
 
     @@exec { "reg_cc_${::hostname}":
       command  => "/usr/sbin/euca_conf \


### PR DESCRIPTION
We need to have the proper credentials in place before attempting
to register NC, otherwise this will happen:

The following expected credentials are missing:
    /var/lib/eucalyptus/keys/node-cert.pem
    /var/lib/eucalyptus/keys/cluster-cert.pem
    /var/lib/eucalyptus/keys/cloud-cert.pem
    /var/lib/eucalyptus/keys/node-pk.pem
    /var/lib/eucalyptus/keys/cluster-pk.pem
